### PR TITLE
Chore / Fix http parser import

### DIFF
--- a/lib/http-parser.rb
+++ b/lib/http-parser.rb
@@ -1,4 +1,4 @@
-require 'http-parser/http_parser'
+require [Gem.loaded_specs['http-parser-lite'].extension_dir, 'http_parser'].join('/')
 
 module HTTP
   class Parser


### PR DESCRIPTION
In order to improve performance and reduce costs we decided to [upgrade from Ruby v2 to Ruby v3](https://www.pivotaltracker.com/story/show/184611345) on the [CBK](https://github.com/NEWROPE/cubki) project. CBK project is using the [invoker](https://github.com/code-mancers/invoker) gem, which is a bit old and depends on [http-parser-lite](https://github.com/deepfryed/http-parser-lite). Unfortunately, `http-parser-lite` is pretty old too, and is not compatible with Ruby v3 as is. There is an issue with executable import.

See the investigation on Slack: https://newrope.slack.com/archives/C02S08WDQ/p1679976577729379?thread_ts=1679297062.851219&cid=C02S08WDQ.